### PR TITLE
Ability Selection Locks and Unlocks

### DIFF
--- a/Assets/Scripts/Controller/ContTarget.cs
+++ b/Assets/Scripts/Controller/ContTarget.cs
@@ -12,11 +12,34 @@ public class ContTarget : MonoBehaviour {
 
 	public int nTarCount;
 
+    public bool bLocked;
+
+    public static ContTarget instance;
+
     public static Subject subAllStartTargetting = new Subject();
     public static Subject subAllFinishTargetting = new Subject();
 
-	// Move to selecting the next target
-	public void IncTar(){
+    //TODO CHANGE ALL .Get() calls in other classes to use properties
+    //     so the syntax isn't as gross
+
+    public static ContTarget Get() {
+        if (instance == null) {
+            GameObject go = GameObject.FindGameObjectWithTag("ContTarget");
+            if (go == null) {
+                Debug.LogError("ERROR! NO OBJECT HAS A ContTarget TAG!");
+            }
+            instance = go.GetComponent<ContTarget>();
+            if (instance == null) {
+                Debug.LogError("ERROR! ContTurns TAGGED OBJECT DOES NOT HAVE A ContTarget COMPONENT!");
+            }
+            instance.Start();
+        }
+        return instance;
+    }
+
+
+    // Move to selecting the next target
+    public void IncTar(){
 		nTarCount++;
 	}
 
@@ -30,10 +53,31 @@ public class ContTarget : MonoBehaviour {
 		nTarCount = 0;
 	}
 
+    // Stop the player from targetting any abilities during a turn
+    public void LockTargetting() {
+
+        CancelTar();
+        bLocked = true;
+    }
+
+    // Allow the player to start targetting abilities again
+    public void UnlockTargetting() {
+
+        bLocked = false;
+
+    }
+
 	// Ends targetting
 	public void CancelTar(){
-		//TODO:: Consider if resetting like this needs to back through the previously selected
-		//       targets and clean them out for the future.
+        //TODO:: Consider if resetting like this needs to back through the previously selected
+        //       targets and clean them out for the future.
+
+        if(curState.GetType() == typeof(StateTargetIdle) || curState.GetType() == typeof(StateTargetSelected)) {
+            // If we're waiting to select a character, or aren't in the process of targetting
+            // an ability with the selected character, then no resetting is needed
+            return;
+        }
+
 		ResetTar();
 		selected.bSetAction = false;
 		selected.nUsingAction = -1;

--- a/Assets/Scripts/Controller/StateTarget/StateTargetIdle.cs
+++ b/Assets/Scripts/Controller/StateTarget/StateTargetIdle.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 public class StateTargetIdle : StateTarget {
 
     public void cbClickChar(Object target, params object[] args) {
+
         contTarg.selected = ((ViewChr)target).mod;
 
         contTarg.SetState(new StateTargetSelected(contTarg));

--- a/Assets/Scripts/Controller/StateTarget/StateTargetSelected.cs
+++ b/Assets/Scripts/Controller/StateTarget/StateTargetSelected.cs
@@ -19,6 +19,12 @@ public class StateTargetSelected : StateTarget {
     public void cbChooseAction(Object target, params object[] args) {
         // When we've clicked an action, use that action
 
+        // But first, check if targetting is locked
+        if (contTarg.bLocked) {
+            Debug.Log("We can't choose an action when locked");
+            return;
+        }
+
         contTarg.selected.Targetting();
         contTarg.selected.nUsingAction = ((ViewAction)target).id;
 

--- a/Assets/Scripts/Model/AbilityEngine/Executables/ExecTurn/ExecTurnEndTurn.cs
+++ b/Assets/Scripts/Model/AbilityEngine/Executables/ExecTurn/ExecTurnEndTurn.cs
@@ -8,6 +8,8 @@ public class ExecTurnEndTurn : Executable {
 
     public void EndTurn() {
 
+        Controller.Get().contTarget.UnlockTargetting();
+
         subAllTurnEnd.NotifyObs(null);
         //TODO - MAKE CHARACTERS OBSERVE THIS AND UNLOCK THEIR ABILITY SELECTION
 

--- a/Assets/Scripts/Model/AbilityEngine/Executables/ExecTurn/ExecTurnStartTurn.cs
+++ b/Assets/Scripts/Model/AbilityEngine/Executables/ExecTurn/ExecTurnStartTurn.cs
@@ -8,8 +8,12 @@ public class ExecTurnStartTurn : Executable {
 
     public void StartTurn() {
 
+        Controller.Get().contTarget.LockTargetting();
+
         subAllTurnStart.NotifyObs(null);
         //TODO - MAKE CHARACTERS OBSERVE THIS AND LOCK THEIR ABILITY SELECTION
+        // Confirm that all characters should be locked in between abilities 
+        //   - don't want weird ability swapping mid-ability selection
 
     }
 


### PR DESCRIPTION
Currently locking every character since maybe mid-turn events would screw up in-progress targetting